### PR TITLE
Batch InfluxDB writes

### DIFF
--- a/index.js
+++ b/index.js
@@ -69,7 +69,7 @@ InfluxOutput.prototype._write = function _write(event, encoding, callback)
 	else
 		self.batch[event.name].push([point, tags]);
 
-	if (self.batchLength === self.batchSize)
+	if (self.batchLength >= self.batchSize)
 	{
 		var batch = self.batch;
 		self.batch = {};

--- a/test.js
+++ b/test.js
@@ -208,6 +208,9 @@ describe('influx client', function()
 			Object.keys(output.client.series).length.must.be.equal(2);
 			output.client.series.test_a.must.be.an.object();
 			output.client.series.test_b.must.be.an.object();
+			output.client.series.test_a[0][0].value.must.be.equal(4);
+			output.client.series.test_b[0][0].value.must.be.equal(5);
+			output.batchLength.must.be.equal(0);
 			done();
 		});
 	});


### PR DESCRIPTION
Set the default batch size to `1` to remain backwards-compatible.

cc @ceejbot 
